### PR TITLE
new version of piwik 2.14.0 breaks php api.

### DIFF
--- a/classes/WP_Piwik/Request/Php.php
+++ b/classes/WP_Piwik/Request/Php.php
@@ -27,8 +27,11 @@
 				require_once PIWIK_INCLUDE_PATH . "/index.php";
 			if (file_exists(PIWIK_INCLUDE_PATH . "/core/API/Request.php"))
 				require_once PIWIK_INCLUDE_PATH . "/core/API/Request.php";
-			if (class_exists('Piwik\FrontController'))
+			if (class_exists('Piwik\FrontController')){
+				$environment = new \Piwik\Application\Environment('tracker');
+				$environment->init();
 				\Piwik\FrontController::getInstance()->init();
+			}
 			else serialize(array('result' => 'error', 'message' => __('Class Piwik\FrontController does not exists.','wp-piwik')));
 			if (class_exists('Piwik\API\Request'))
 				$request = new \Piwik\API\Request($params.'&token_auth='.self::$settings->getGlobalOption('piwik_token'));


### PR DESCRIPTION
Workaround to avoid this : https://github.com/piwik/piwik/issues/8311. Error: Fatal error: Uncaught exception 'Piwik\Container\ContainerDoesNotExistException' with message 'The root container has not been created yet.'
No regression test done.
I pick corrections  here : http://forum.piwik.org/read.php?2,127892.Fully functional in 3 different instances of piwik.
