### PR TITLE
Apply filter to tracking code so other plugins can modify it

### DIFF
--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -24,6 +24,7 @@ class TrackingCode {
 			$this->applySearchChanges ();
 		if (is_single ())
 			$this->addCustomValues ();
+		$this->trackingCode = apply_filters('wppiwik_tracking_code', $this->trackingCode);
 		return $this->trackingCode;
 	}
 


### PR DESCRIPTION
I would like to modify the tracking code and eg add a Piwik tracker method `_paq.push(['setCookieDomain', ...])` and `_paq.push(['setDomains', [...]])`. By applying a filter, other plugins could modify the tracking code in the way they want. Let me know if there are any questions.
